### PR TITLE
Disable search field zoom

### DIFF
--- a/webclient/index.html
+++ b/webclient/index.html
@@ -9,7 +9,7 @@
         <meta name="apple-mobile-web-app-status-bar-style" content="black" />
 	<meta name="HandheldFriendly" content="True">
         <meta name="MobileOptimized" content="320">
-        <meta name="viewport" content="initial-scale=1.0, user-scalable=no">
+        <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width, maximum-scale=1">
 	<meta name="apple-mobile-web-app-capable" content="yes">
         <meta name="apple-mobile-web-app-status-bar-style" content="black">
         <meta name="apple-mobile-web-app-title" content="MusicBox">


### PR DESCRIPTION
Safari automagically zooms the input field and since user zooming is
disabled you cannot reset the zoom level.
