### PR TITLE
Allow to search for Spotify playlists by Spotify URI.

### DIFF
--- a/webclient/js/library.js
+++ b/webclient/js/library.js
@@ -28,18 +28,26 @@ function initSearch() {
         delete customTracklists['trackresultscache'];
         $("#searchresults").hide();
 
-        var query = {},
-            uris = [];
+        mopidy.getUriSchemes().then(function (schemes) {
+            var query = {},
+                uris = [];
 
-        if (value.match(/^spotify:/)) {
-            query = {uri: [value]};
-            uris = ["spotify:"];
-        } else {
-            query = {any: [value]};
-        }
+            var regexp = $.map(schemes, function (scheme) {
+                return '^' + scheme + ':';
+            }).join('|');
 
-        mopidy.library.search(query, uris).then(processSearchResults, console.error);
-        // console.log('search sent', value);
+            var match = value.match(regexp);
+            if (match) {
+                var scheme = match[0];
+                query = {uri: [value]};
+                uris = [scheme];
+            } else {
+                query = {any: [value]};
+            }
+
+            mopidy.library.search(query, uris).then(processSearchResults, console.error);
+            // console.log('search sent', value);
+        });
     }
 }
 


### PR DESCRIPTION
This allows you to enter Spotify URI like e.g. `spotify:user:spotify:playlist:2Qi8yAzfj1KavAhWz1gaem` and will return the list of all tracks in this playlist. For some reason though the first time you click "Search" button, almost all tracks are returned like `[loading] spotify:track:0iVmK9TXETx9mBAiDnuo7k`. When you click "Search" button the second time, everything is ok. No idea why it works like that.
