### PR TITLE
Better handling of keyboard shortcuts and fixes removing tracks from queue

### DIFF
--- a/mopidy_musicbox_webclient/static/js/controls.js
+++ b/mopidy_musicbox_webclient/static/js/controls.js
@@ -236,7 +236,7 @@ function removeTrack() {
     }
     var track = {};
     track.uri = [currentplaylist[i].uri];
-    mopidy.tracklist.remove(track);
+    mopidy.tracklist.remove({'uri':track.uri});
     //    console.log(currentplaylist[i].uri);
 }
 

--- a/mopidy_musicbox_webclient/static/js/gui.js
+++ b/mopidy_musicbox_webclient/static/js/gui.js
@@ -509,8 +509,10 @@ $(document).ready(function(event) {
     $(document).keypress( function (event) {
 	//console.log('kp:    '+event);
 	if (event.target.tagName != 'INPUT') {
-	    switch(event.which) {
-	        case 32:
+	    var unicode=event.keyCode? event.keyCode : event.charCode;
+	    var actualkey=String.fromCharCode(unicode);
+	    switch(actualkey) {
+	        case ' ':
     		    doPlay();
     		    event.preventDefault();
 		    break;

--- a/mopidy_musicbox_webclient/static/js/gui.js
+++ b/mopidy_musicbox_webclient/static/js/gui.js
@@ -508,17 +508,19 @@ $(document).ready(function(event) {
 
     $(document).keypress( function (event) {
 	//console.log('kp:    '+event);
-	if (event.target.tagName != 'INPUT') { 
-	    event.preventDefault();
+	if (event.target.tagName != 'INPUT') {
 	    switch(event.which) {
 	        case 32:
     		    doPlay();
+    		    event.preventDefault();
 		    break;
 		case '>':
     		    doNext();
+    		    event.preventDefault();
 		    break;
 		case '<':
     		    doPrevious();
+    		    event.preventDefault();
 		    break;
 	    }
 	    return true;


### PR DESCRIPTION
Explicitly translate key codes to actual characters before executing keyboard shortcuts. Current implementation seems to use a combination of key codes and characters in the switch statement which does not appear to work on all platforms (e.g. Safari on Mac OS).

Also contains fixes for issue #63, restores track removal functionality of issue #4, and addresses https://github.com/woutervanwijk/Pi-MusicBox/issues/118