### PR TITLE
Fix jQuery version in script filename

### DIFF
--- a/mopidy_musicbox_webclient/static/dialog-success.html
+++ b/mopidy_musicbox_webclient/static/dialog-success.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
 
-    <script src="js/jquery-1.10.2.min.js"></script>
+    <script src="js/jquery-1.11.1.min.js"></script>
     <link rel="stylesheet" type="text/css" href="css/jquery.mobile.flatui.css"/>
     <script src="js/jquery.mobile-1.3.2.min.js"></script>
 </head>


### PR DESCRIPTION
This updates jQuery version in referenced script filename in file `dialog-success.html`. The same pull-request as for `master` branch.

I noticed old jQuery version (1.10.2) being referenced in `dialog-success.html` and `system.html` after PIP-updating all packages on my Pi MusicBox. Could you please publish the fix in PIP also?

Meanwhile for other users facing this issue (non-working Shutdown/Reboot/Cancel form after PIP-updating packages on Pi MusicBox) I can suggest workaround - fixing files by shell command `sed -i 's/jquery-1\.10\.2\.min\.js/jquery-1.11.1.min.js/g' /usr/local/lib/python2.7/dist-packages/mopidy_musicbox_webclient/static/*.html`.