### PR TITLE
Keep track of browsing tracks

### DIFF
--- a/mopidy_musicbox_webclient/static/js/controls.js
+++ b/mopidy_musicbox_webclient/static/js/controls.js
@@ -41,9 +41,9 @@ function playBrowsedTracks(addtoqueue, trackid) {
                     if (this.id == trackid) {
                         selected = counter;
                     }
-                    mopidy.tracklist.add(null, null, this.id);
                     counter++;
                 });
+                mopidy.tracklist.add(browseTracks);
                 break;
             default:
                 break;

--- a/mopidy_musicbox_webclient/static/js/functionsvars.js
+++ b/mopidy_musicbox_webclient/static/js/functionsvars.js
@@ -47,6 +47,7 @@ var customPlaylists = [];
 var customTracklists = [];
 
 var browseStack = [];
+var browseTracks = [];
 
 var ua = navigator.userAgent,
     isMobileSafari = /Mac/.test(ua) && /Mobile/.test(ua),

--- a/mopidy_musicbox_webclient/static/js/process_ws.js
+++ b/mopidy_musicbox_webclient/static/js/process_ws.js
@@ -106,12 +106,14 @@ function processBrowseDir(resultArr) {
 	child += backHtml;
     }
 
+    browseTracks = [];
     for (var i = 0; i < resultArr.length; i++) {
         iconClass = getMediaClass(resultArr[i].uri);
 	if(resultArr[i].type == 'track' ) {
 //	    console.log(resultArr[i]);
         mopidy.library.lookup(resultArr[i].uri).then(function (resultArr) {
             popupData[resultArr[0].uri] = resultArr[0];
+            browseTracks.push(resultArr[0]);
         }, console.error);
         child += '<li class="song albumli" id="browselisttracks-' + resultArr[i].uri + '">' +
 		'<a href="#" class="moreBtn" onclick="return popupTracks(event, \'' + uri + '\', \'' + resultArr[i].uri + '\');">' +


### PR DESCRIPTION
Store browsing tracks in global "browseTracks" for playing all tracks.
Add all tracks at one time to lower internet overhead.
Hope this could resolve issue #85 