### PR TITLE
Add link to Alarm Clock

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,7 @@ v2.0.1 (UNRELEASED)
 - Added optional websocket_host and websocket_port config settings.
 - Support for Mopidy-Grooveshark.
 - Fixed slow to start playing from a large tracklist of browsed tracks.
+- Added link to `Alarm Clock <https://pypi.python.org/pypi/Mopidy-AlarmClock/>`_ (if present).
 
 v2.0.0 (26-3-2015)
 ------------------

--- a/mopidy_musicbox_webclient/static/index.html
+++ b/mopidy_musicbox_webclient/static/index.html
@@ -9,7 +9,8 @@
     <script>
         //configuration
         var isMusicBox = {{musicbox}}; // Remove MusicBox only content (e.g. settings, system pages)
-        var websocketUrl = '{{websocket_url}}'
+        var websocketUrl = '{{websocket_url}}';
+        var hasAlarmClock = {{alarmclock}}; // Add Alarm Clock icons
 
         $(document).bind("mobileinit", function () {
             $.extend($.mobile, {
@@ -95,6 +96,10 @@
         <li id="navsearch" data-icon="false">
             <a href="#search" onclick="switchContent('search' ); return false;">
                 <span class="navtxt">Search </span><i class="fa fa-search"></i></a>
+        </li>
+        <li id="navAlarmClock" data-icon="false">
+                <a href="/alarmclock/">
+                <span class="navtxt"> Alarm Clock </span><i class="fa fa-clock-o"></i></a>
         </li>
         <li id="navEnterFullscreen" data-icon="false">
                 <a href="#">
@@ -264,6 +269,12 @@
             <div class="ui-block-b">
                 <i class="fa fa-search"></i>
                 <h4>Search</h4>
+            </div>
+        </a>
+        <a id="homeAlarmClock" href="/alarmclock/">
+            <div class="ui-block-a">
+                <i class="fa fa-clock-o"></i>
+                <h4>Alarm Clock</h4>
             </div>
         </a>
         <a id="homesettings" href="/settings/">

--- a/mopidy_musicbox_webclient/static/index.html
+++ b/mopidy_musicbox_webclient/static/index.html
@@ -278,13 +278,13 @@
             </div>
         </a>
         <a id="homesettings" href="/settings/">
-            <div class="ui-block-a">
+            <div class="ui-block-b">
                 <i class="fa fa-gear"></i>
                 <h4>Settings</h4>
             </div>
         </a>
         <a id="homeshutdown" href="system.html">
-            <div class="ui-block-b">
+            <div class="ui-block-a">
                 <i class="fa fa-power-off"></i>
                 <h4>System</h4>
             </div>

--- a/mopidy_musicbox_webclient/static/js/gui.js
+++ b/mopidy_musicbox_webclient/static/js/gui.js
@@ -525,6 +525,7 @@ $(document).ready(function(event) {
     if (!hasAlarmClock) {
         $('#navAlarmClock').hide();
         $('#homeAlarmClock').hide();
+        $('#homeAlarmClock').nextAll().find('.ui-block-a, .ui-block-b').toggleClass('ui-block-a').toggleClass('ui-block-b');
     }
 
     //navigation stuff

--- a/mopidy_musicbox_webclient/static/js/gui.js
+++ b/mopidy_musicbox_webclient/static/js/gui.js
@@ -521,6 +521,12 @@ $(document).ready(function(event) {
         $('#homeshutdown').hide();
     }
 
+    // remove Alarm Clock if it is not present
+    if (!hasAlarmClock) {
+        $('#navAlarmClock').hide();
+        $('#homeAlarmClock').hide();
+    }
+
     //navigation stuff
 
     $(document).keypress( function (event) {

--- a/mopidy_musicbox_webclient/web.py
+++ b/mopidy_musicbox_webclient/web.py
@@ -45,7 +45,9 @@ class IndexHandler(tornado.web.RequestHandler):
             'version': MusicBoxExtension.version,
             'musicbox': int(ext_config['musicbox'] or False),
             'websocket_url': ws_url,
-            'alarmclock': int('alarmclock' in config and 'enabled' in config['alarmclock'] and config['alarmclock']['enabled'])
+            'alarmclock': int('alarmclock' in config and 
+                'enabled' in config['alarmclock'] and 
+                config['alarmclock']['enabled'])
         }
         self.__path = path
 

--- a/mopidy_musicbox_webclient/web.py
+++ b/mopidy_musicbox_webclient/web.py
@@ -45,9 +45,9 @@ class IndexHandler(tornado.web.RequestHandler):
             'version': MusicBoxExtension.version,
             'musicbox': int(ext_config['musicbox'] or False),
             'websocket_url': ws_url,
-            'alarmclock': int('alarmclock' in config and 
-                'enabled' in config['alarmclock'] and 
-                config['alarmclock']['enabled'])
+            'alarmclock': int('alarmclock' in config and
+                              'enabled' in config['alarmclock'] and
+                              config['alarmclock']['enabled'])
         }
         self.__path = path
 

--- a/mopidy_musicbox_webclient/web.py
+++ b/mopidy_musicbox_webclient/web.py
@@ -41,17 +41,11 @@ class IndexHandler(tornado.web.RequestHandler):
                                'using %s', port)
             ws_url = "ws://%s:%d/mopidy/ws" % (host, port)
 
-        alarmclock = False
-        try:
-            alarmclock = config['alarmclock']['enabled']
-        except:
-            pass
-
         self.__dict = {
             'version': MusicBoxExtension.version,
             'musicbox': int(ext_config['musicbox'] or False),
             'websocket_url': ws_url,
-            'alarmclock': int(alarmclock)
+            'alarmclock': int('alarmclock' in config and 'enabled' in config['alarmclock'] and config['alarmclock']['enabled'])
         }
         self.__path = path
 

--- a/mopidy_musicbox_webclient/web.py
+++ b/mopidy_musicbox_webclient/web.py
@@ -41,11 +41,17 @@ class IndexHandler(tornado.web.RequestHandler):
                                'using %s', port)
             ws_url = "ws://%s:%d/mopidy/ws" % (host, port)
 
+        alarmclock = False
+        try:
+            alarmclock = config['alarmclock']['enabled']
+        except:
+            pass
+
         self.__dict = {
             'version': MusicBoxExtension.version,
             'musicbox': int(ext_config['musicbox'] or False),
             'websocket_url': ws_url,
-            'alarmclock': int(config['alarmclock']['enabled'])
+            'alarmclock': int(alarmclock)
         }
         self.__path = path
 

--- a/mopidy_musicbox_webclient/web.py
+++ b/mopidy_musicbox_webclient/web.py
@@ -44,7 +44,8 @@ class IndexHandler(tornado.web.RequestHandler):
         self.__dict = {
             'version': MusicBoxExtension.version,
             'musicbox': int(ext_config['musicbox'] or False),
-            'websocket_url': ws_url
+            'websocket_url': ws_url,
+            'alarmclock': int(config['alarmclock']['enabled'])
         }
         self.__path = path
 


### PR DESCRIPTION
Add link to [Mopidy-AlarmClock](https://github.com/DavisNT/mopidy-alarmclock) if it is enabled in Mopidy config (e.g. installed and loaded).

Related to https://github.com/woutervanwijk/Pi-MusicBox/issues/270